### PR TITLE
Enhance store/kv module with caching, TTL support, and batch operations

### DIFF
--- a/store/kv/cache.go
+++ b/store/kv/cache.go
@@ -1,0 +1,64 @@
+package kv
+
+import (
+	"container/list"
+	"sync"
+)
+
+// LRU Cache implementation
+type LRUCache struct {
+	capacity int
+	cache    map[string]*list.Element
+	list     *list.List
+	mu       sync.Mutex
+}
+
+type entry struct {
+	key   string
+	value []byte
+}
+
+// NewLRUCache creates a new LRU cache
+func NewLRUCache(capacity int) *LRUCache {
+	return &LRUCache{
+		capacity: capacity,
+		cache:    make(map[string]*list.Element),
+		list:     list.New(),
+	}
+}
+
+// Get retrieves an item from the cache
+func (c *LRUCache) Get(key string) ([]byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if elem, found := c.cache[key]; found {
+		c.list.MoveToFront(elem)
+		return elem.Value.(*entry).value, true
+	}
+	return nil, false
+}
+
+// Put adds an item to the cache
+func (c *LRUCache) Put(key string, value []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if elem, found := c.cache[key]; found {
+		c.list.MoveToFront(elem)
+		elem.Value.(*entry).value = value
+		return
+	}
+
+	if c.list.Len() >= c.capacity {
+		// Evict the least recently used item
+		elem := c.list.Back()
+		c.list.Remove(elem)
+		delete(c.cache, elem.Value.(*entry).key)
+	}
+
+	newEntry := &entry{key, value}
+	elem := c.list.PushFront(newEntry)
+	c.cache[key] = elem
+}
+

--- a/store/kv/ttl.go
+++ b/store/kv/ttl.go
@@ -1,0 +1,67 @@
+package kv
+
+import (
+	"sync"
+	"time"
+)
+
+// TTLCache extends LRUCache to support TTL
+type TTLCache struct {
+	cache     *LRUCache
+	expiries  map[string]time.Time
+	mu        sync.Mutex
+	ttlWorker *time.Ticker
+}
+
+// NewTTLCache creates a TTL-enabled cache
+func NewTTLCache(capacity int, cleanupInterval time.Duration) *TTLCache {
+	c := &TTLCache{
+		cache:     NewLRUCache(capacity),
+		expiries:  make(map[string]time.Time),
+		ttlWorker: time.NewTicker(cleanupInterval),
+	}
+
+	go c.cleanup()
+	return c
+}
+
+// Put adds an item with TTL
+func (c *TTLCache) Put(key string, value []byte, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	expiry := time.Now().Add(ttl)
+	c.cache.Put(key, value)
+	c.expiries[key] = expiry
+}
+
+// Get retrieves an item, checking TTL
+func (c *TTLCache) Get(key string) ([]byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if expiry, exists := c.expiries[key]; exists {
+		if time.Now().After(expiry) {
+			// Item expired, remove it
+			c.cache.Remove(key)
+			delete(c.expiries, key)
+			return nil, false
+		}
+	}
+	return c.cache.Get(key)
+}
+
+// Cleanup removes expired items
+func (c *TTLCache) cleanup() {
+	for range c.ttlWorker.C {
+		c.mu.Lock()
+		for key, expiry := range c.expiries {
+			if time.Now().After(expiry) {
+				c.cache.Remove(key)
+				delete(c.expiries, key)
+			}
+		}
+		c.mu.Unlock()
+	}
+}
+


### PR DESCRIPTION
本 PR 为 store/kv 模块引入以下改进：

- 缓存机制：
新增基于 LRU 的缓存，提升读操作性能并减少后端存储访问。
将缓存集成到 Get 和 Set 操作中。
TTL（生存时间）支持：

- 新增 TTL 支持的缓存（TTLCache），可自动清理过期的键值对。
在 Get 和 SetWithTTL 操作中加入 TTL 支持。
- 批量操作：
实现 BatchGet 方法，支持高效的多键值批量读取操作。
详细改动：

## 新增文件：

store/kv/cache.go：实现 LRU 缓存。
store/kv/ttl.go：实现支持 TTL 的缓存。
## 修改文件：

store/kv/kv_store.go：将缓存、TTL 和批量操作集成到现有的键值存储逻辑中。
改进优势：

## 说明
通过缓存机制提升性能。
通过 TTL 自动清理功能优化存储管理。
支持批量操作，提高多键值读取的吞吐量。
测试情况：

为缓存和 TTL 逻辑新增单元测试。
验证批量操作功能的正确性。